### PR TITLE
override bulma's overflow-y

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,10 @@
   src: local('Ubuntu Bold'), local('Ubuntu-Bold'), url(assets/fonts/ubuntu.woff) format('woff');
 }
 
+html {
+  overflow-y: auto !important; /* override bulma */
+}
+
 #appx {
   font-family: Avenir, Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
Die Bulma CSS setzt `overflow-y` auf `scroll` (https://github.com/kaihoefler/livestream/blob/b35a2dd7b740d52148038d2dab6317d302285cd9/src/assets/traina_bulma.css#L270) wodurch permanent eine vertikale Scrollbar angezeigt wird. Vor #1 wurde dieser Default per JavaScript überschrieben: https://github.com/kaihoefler/livestream/pull/1/files#diff-c40213613d7e5be00cbacf17ba94623645148b8d5b6d37e135dc46851d2bbff2L68-L69. Mit der Vorschau geht dies jedoch nichtmehr, da man sonst den Controller nicht mehr scrollen könnte.

Dieser PR setzt `overflow-y` auf `auto` wodurch die Scrollbar nur angezeigt wird, wenn sie benötigt wird.

Ich habe das Bulma CSS bewusst nicht angepasst, damit es in Zukunft einfacher wird Bulma als dependency ins Projekt zu ziehen.

Getestet: Controller hat eine Scrollbar, Visualization nicht